### PR TITLE
Add OpenAI integration and API key setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and replace with your actual OpenAI API key
+OPENAI_API_KEY=your_openai_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Local environment variables
+.env
+
+# Python cache
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -31,3 +31,20 @@ The app will be split into modular Python files for clarity, with a main app.py 
 
 ## Implementation
 Below is the complete code for the app. Each module is designed to be modular and reusable, with Streamlit providing the interactive UI. I'll include comments for clarity and instructions for deployment at the end.
+
+## OpenAI API Key Setup
+Some features use OpenAI's API. Install requirements and provide an API key through an environment variable.
+
+### Using shell environment
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+### Using a `.env` file
+Create a `.env` file (use `.env.example` as a template) with the following line:
+
+```
+OPENAI_API_KEY=sk-...
+```
+
+The application will raise an error at startup if this key is not supplied.

--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 # Databricks notebook source
+import os
 import streamlit as st
 import pandas as pd
+import openai
 from knowledge_base import search_knowledge_base, init_knowledge_base
 from prompt_builder import build_prompt
 from notebook import run_notebook
@@ -8,6 +10,12 @@ from data_dictionary import upload_data_dictionary, search_data_dictionary, init
 from data_cleaning import clean_data
 from eda import perform_eda
 from io import BytesIO
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+if not openai.api_key:
+    raise ValueError(
+        "OPENAI_API_KEY environment variable is not set. Please set it in your environment or .env file."
+    )
 
 st.set_page_config(page_title="Data Analytics Hub", layout="wide", initial_sidebar_state="collapsed")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib==3.9.2
 seaborn==0.13.2
 pyspark==3.5.2
 openpyxl==3.1.5
+openai==1.99.9


### PR DESCRIPTION
## Summary
- add `openai` to application dependencies
- configure `app.py` to read `OPENAI_API_KEY` and raise an error if missing
- document API key configuration and provide `.env.example`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a0efbf90f4832e969b8582bac6db35