### PR TITLE
Add tests for ETL agent, data dictionary, and cleaning

### DIFF
--- a/tests/test_data_cleaning.py
+++ b/tests/test_data_cleaning.py
@@ -1,0 +1,50 @@
+import io
+from pathlib import Path
+import sys
+
+# ensure module import
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+import data_cleaning
+import types
+
+
+class DummyContext:
+    def __enter__(self):
+        return None
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_clean_data_basic_flow(monkeypatch):
+    sample_csv = "col1,col2\n1,2\n,3\n1,2\n"
+    uploaded = io.StringIO(sample_csv)
+
+    monkeypatch.setattr(data_cleaning.st, "file_uploader", lambda *a, **k: uploaded)
+    monkeypatch.setattr(data_cleaning.st, "columns", lambda n: (DummyContext(), DummyContext()))
+    monkeypatch.setattr(data_cleaning.st, "write", lambda *a, **k: None)
+    monkeypatch.setattr(data_cleaning.st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(data_cleaning.st, "selectbox", lambda *a, **k: "Drop")
+    monkeypatch.setattr(data_cleaning.st, "button", lambda *a, **k: True)
+    monkeypatch.setattr(data_cleaning.st, "checkbox", lambda *a, **k: False)
+    monkeypatch.setattr(data_cleaning.st, "download_button", lambda *a, **k: None)
+    monkeypatch.setattr(data_cleaning.st, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(data_cleaning.st, "error", lambda *a, **k: None)
+    data_cleaning.st.session_state = types.SimpleNamespace()
+
+    class DummyExcelWriter:
+        def __init__(self, *a, **k):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(data_cleaning.pd, "ExcelWriter", DummyExcelWriter)
+
+    data_cleaning.clean_data()
+    cleaned = getattr(data_cleaning.st.session_state, "cleaned_df", None)
+    assert cleaned is not None
+    assert cleaned.shape == (1, 2)
+    assert list(cleaned.columns) == ["col1", "col2"]

--- a/tests/test_data_dictionary.py
+++ b/tests/test_data_dictionary.py
@@ -1,0 +1,26 @@
+import io
+from pathlib import Path
+import sys
+
+# ensure module import
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import data_dictionary
+
+
+def test_upload_and_search(tmp_path, monkeypatch):
+    sample_csv = (
+        "id,database_name,table_name,column_name,data_type,description,relationships\n"
+        "1,db,users,id,INTEGER,identifier,"
+    )
+    uploaded = io.StringIO(sample_csv)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(data_dictionary.st, "file_uploader", lambda *a, **k: uploaded)
+    monkeypatch.setattr(data_dictionary.st, "success", lambda *a, **k: None)
+    monkeypatch.setattr(data_dictionary.st, "error", lambda *a, **k: None)
+
+    data_dictionary.upload_data_dictionary()
+    results = data_dictionary.search_data_dictionary("id")
+    assert len(results) == 1
+    assert results[0]["column_name"] == "id"

--- a/tests/test_etl_agent.py
+++ b/tests/test_etl_agent.py
@@ -1,0 +1,49 @@
+import sqlite3
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+# ensure module import
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from etl_agent import load_data_dictionary, build_etl_plan
+
+
+def _create_data_dictionary(db_path: Path):
+    conn = sqlite3.connect(db_path)
+    df = pd.DataFrame(
+        {
+            "database_name": ["db"],
+            "table_name": ["users"],
+            "column_name": ["id"],
+            "data_type": ["INTEGER"],
+            "description": ["user id"],
+            "relationships": [""]
+        }
+    )
+    df.to_sql("data_dictionary", conn, if_exists="replace", index=False)
+    conn.close()
+
+
+def test_load_data_dictionary(tmp_path, monkeypatch):
+    db_path = tmp_path / "app.db"
+    _create_data_dictionary(db_path)
+    monkeypatch.chdir(tmp_path)
+    df_loaded = load_data_dictionary()
+    assert df_loaded.iloc[0]["table_name"] == "users"
+    assert "description" in df_loaded.columns
+
+
+def test_build_etl_plan():
+    df = pd.DataFrame(
+        {
+            "table_name": ["users", "orders"],
+            "relationships": ["", "users.id -> orders.user_id"],
+        }
+    )
+    tables = ["users", "orders"]
+    steps = build_etl_plan(df, tables)
+    assert steps[0] == "Load table `users`"
+    assert any("Join `orders`" in step for step in steps)
+    assert steps[-1] == "Select necessary columns and apply transformations"


### PR DESCRIPTION
## Summary
- add ETL agent tests for data dictionary loading and ETL plan building
- cover data dictionary upload and search behaviors
- test data cleaning flow with missing values and duplicates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f5106150832e9f6b2955a556e3fb