### PR TITLE
Reorder imports in ETL agent tests

### DIFF
--- a/tests/test_etl_agent.py
+++ b/tests/test_etl_agent.py
@@ -1,5 +1,5 @@
-import sqlite3
 from pathlib import Path
+import sqlite3
 import sys
 
 import pandas as pd


### PR DESCRIPTION
## Summary
- Place Path and sqlite3 imports at top of ETL agent tests

## Testing
- `pytest tests/test_etl_agent.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a1050ebd1c832eb22d5aef32a319f9