### PR TITLE
chore: remove duplicate openai requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ openpyxl==3.1.5
 openai==1.99.9
 requests==2.32.3
 beautifulsoup4==4.12.3
-openai>=1.0.0


### PR DESCRIPTION
## Summary
- remove duplicate OpenAI requirement so only `openai==1.99.9` remains

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas'; ModuleNotFoundError: No module named 'streamlit')*


------
https://chatgpt.com/codex/tasks/task_e_68a105136e50832e97853fba80a85335