### PR TITLE
Instantiate OpenAI client within run_agent

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -2,12 +2,11 @@ import os
 import streamlit as st
 from openai import OpenAI
 
-client = OpenAI()
-
 def run_agent():
     if not os.getenv("OPENAI_API_KEY"):
         st.warning("Set the OPENAI_API_KEY environment variable to use the agent.")
         return
+    client = OpenAI()
     st.write("Interact with the OpenAI-powered data science agent.")
     prompt = st.text_area("Ask a question or describe a task:")
     if st.button("Run Agent") and prompt:


### PR DESCRIPTION
## Summary
- remove global OpenAI client from agents module
- create OpenAI client locally inside run_agent after API key check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas==2.2.2 streamlit==1.38.0` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68a105282ed8832e8b6ad61afaf8c87d