### PR TITLE
chore: remove redundant openai requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ openpyxl==3.1.5
 openai==1.99.9
 requests==2.32.3
 beautifulsoup4==4.12.3
-openai>=1.0.0


### PR DESCRIPTION
## Summary
- remove duplicate openai dependency

## Testing
- `pip install pandas streamlit requests beautifulsoup4 openpyxl >/tmp/pip_install.log && tail -n 20 /tmp/pip_install.log`
- `pytest -q` *(fails: search_knowledge_base() got an unexpected keyword argument 'db_path')*

------
https://chatgpt.com/codex/tasks/task_e_68a1052739a0832eae467063d7a4a068